### PR TITLE
osgimodule and lrdeptree.sh improvements to avoid infinite loop

### DIFF
--- a/lrdeptree.sh
+++ b/lrdeptree.sh
@@ -1,4 +1,10 @@
 #!/usr/env bash
+set -o errexit
+
+if [ -z ${PROJECT_HOME} ]
+then
+  PROJECT_HOME=$(git rev-parse --show-toplevel)
+fi
 
 MODULES=${1:-$(mktemp)}
 PROJECT_HOME=${2:-$PROJECT_HOME}

--- a/osgimodule
+++ b/osgimodule
@@ -8,6 +8,12 @@ else
   Start="$PROJECT_HOME/$DIR"
 fi
 
+if [ ! -d ${Start} ] && [ ! -f ${Start} ]
+then
+  echo "Error: ${Start} not found!!!"
+  exit -1
+fi
+
 while [ ! -f "${Start}/bnd.bnd" ]
 do
   if [ "$Start" = "$PROJECT_HOME" ]

--- a/osgimodule
+++ b/osgimodule
@@ -1,5 +1,12 @@
 #!/usr/env bash
+set -o errexit
+
 readonly DIR=$1
+
+if [ -z ${PROJECT_HOME} ]
+then
+  PROJECT_HOME=$(git rev-parse --show-toplevel)
+fi
 
 if [[ $DIR = /* ]]
 then


### PR DESCRIPTION
Hi Adam,

Thanks for sharing your tools! I think they are really useful!

After testing them, I have detected some minor issues:
  - In osgimodule the folder doesn't exist, there is no a graceful error.
  - If you don't define PROJECT_HOME var, a infinite loop ocurrs in osgimodule

I don't like to define a PROJECT_HOME var, because I work with several branches from 7.0 to 7.4, so I have added a new code that calculates it from git repository:

```
set -o errexit

if [ -z ${PROJECT_HOME} ]
then
  PROJECT_HOME=$(git rev-parse --show-toplevel)
fi
```

The "set -o errexit" aborts the script in case git fails, instead of filling the variable with an empty value.

Let me know if you find these changes useful or you have any question.

Regards,
Jorge
